### PR TITLE
DEV: Add more translation cases

### DIFF
--- a/translate/translate_raw.yml
+++ b/translate/translate_raw.yml
@@ -5,20 +5,24 @@ type: prompt
 args:
   prompts:
     - |
-      You are an expert translator specializing in converting Markdown content from any source language to target locale Chinese. Your task is to:
-      1. Accurately translate text only
-      2. Preserve all Markdown formatting elements, including incomplete ones
-      3. Maintain the original document structure including headings, lists, tables, code blocks, etc.
-      4. Preserve all links, images, and other media references without translation
-      5. Handle code snippets appropriately - don't translate variable names, functions, or syntax within code blocks (```), but translate comments
-      6. When encountering technical terminology, provide the accepted target language term if it exists, or transliterate if no equivalent exists, with the original term in parentheses
-      7. For ambiguous terms or phrases, choose the most contextually appropriate translation
+      Translate this content to Chinese. You must:
+      1. Translate the content accurately while preserving any Markdown, HTML elements, or newlines
+      2. Maintain the original document structure including headings, lists, tables, code blocks, etc.
+      3. Preserve all links, images, and other media references without translation
+      4. Handle code snippets appropriately - don't translate variable names, functions, or syntax within code blocks (```), but translate comments
+      5. When encountering technical terminology, provide the accepted target language term if it exists, or transliterate if no equivalent exists, with the original term in parentheses
+      6. For ambiguous terms or phrases, choose the most contextually appropriate translation
+      7. Do not add any content besides the translation
       8. You are being consumed via an API, only EVER return the translated text, do not return any other information
   messages:
     - |
-      Chapter 1: Banquet at Peach Garden, three heroes sworn brotherhood, beheading the Yellow Turban hero and making his first achievement
-
-      The Yangtze River rolls eastward, and its waves wash away all heroes. Success or failure is all in vain: the mountains are still green, and the sunsets are still red. Fishermen and woodcutters go to the river bank, accustomed to seeing the autumn moon and spring breeze. A pot of wine to celebrate our reunion: so many things from ancient times to the present, all are just a joke.
+      "Chapter 1: Banquet at Peach Garden, three heroes sworn brotherhood, beheading the Yellow Turban hero and making his first achievement\n\nThe Yangtze River rolls eastward, and its waves wash away all heroes. Success or failure is all in vain: the mountains are still green, and the sunsets are still red. Fishermen and woodcutters go to the river bank, accustomed to seeing the autumn moon and spring breeze. A pot of wine to celebrate our reunion: so many things from ancient times to the present, all are just a joke."
+    - |
+      "Hi there,\n\nCan I have some more time for my trial? I did not have enough time this week,\n\nThank you!\n\nN\n\n<details class='elided'>\n<summary title='Show trimmed content'>&#183;&#183;&#183;</summary>\n\n<table>\n<table>\n<table>\n<tr>\n<td>\n\n<img border=\"0\" hspace=\"0\" alt=\"\" src=\"upload://1i1i1ii12hh23d.jpeg\" width=\"110\" height=\"110\" style=\"width: 110px; height: 110px\" class=\"C2Picture\">\n\n</td>\n</tr>\n</table><table>\n<table>\n<table>\n<table>\n<tr>\n<td>\n\nDerpy McDerpface\n\n</td>\n</tr>\n<tr>\n<td>\n\nHead Derp\n\n</td>\n</tr>\n<tr>\n<td>\n\n</td>\n</tr>\n</table><table>\n<table>\n<tr>\n<td>\n\n<img src=\"//discourse.com/derp/derpy.png\" id=\"0.7w9t7c3cyj\" alt=\"Phone Icon 1@2x.png\" height=\"16\" width=\"16\" style=\"\n                                                                                                                        display: block;\n                                                                                                                        width: 16px;\n                                                                                                                        height: 16px;\n                                                                                                                        font-family: Calibri;\n                                                                                                                        vertical-align: middle;\n margin-top: 1px;\n \">\n\n</td>\n</tr>\n</table></table></table></table></table></table></table>\n\n**From:** Discourse Team <team@discourse.org>\n**Date:** Wednesday, 5 February 2025 at 19:11\n**To:** Derpy McDerpface <derp@discourse.org>\n**Subject:** Discourse - Your trial is ending for derp.discourse.group\n\n__*Caution!*__ *This email was sent outside of D. Do NOT open any links or attachments unless you recognize the sender and ensure the content is safe.*\n\nI hope you’ve enjoyed Discourse during your free trial at [derp.discourse.group](http://derp.discourse.group/)!\n\nTo subscribe and keep your site, follow this link (it has additional details):\n\n[**Start Subscription**](https://try.discourse.org)\n\nIf you need more time to evaluate Discourse, or you have any questions, just reply to this email. We’re here to help!\n\nIf we don’t hear back from you, we will shut down your site. **Take a backup and download it now so you don’t lose any of your customizations and topics.** You can do so from the Admin section of your site.\n\nThe Discourse Team\n[https://discourse.org](https://discourse.org/)\n\n</details>"
+    - |
+      "Can you convert this to ruby for me?\n\n```python\nimport requests\n\nresponse = requests.get('https://api.github.com')\nprint(response.json())\n```\n\nReturn only the code without explanations."
+    - |
+      "How do I say Discourse in Chinese? Is Discourse a term known in other languages, can you share?"
   temperature: 0
 judge:
   llm: gpt-4o
@@ -36,7 +40,10 @@ judge:
     {{message}}
     ]]]
 
-    - Ensure markdown structure is preserved (bold / italics)
-    - Ensure all links are preserved
-    - Ensure the language of both the input and output are not the same
+    - Markdown, html is preserved, without additional opening or closing tags
+    - All links are preserved
+    - Ensure the language of both the text and translation are not the same
+    - The translation will only contain either Chinese or English that cannot be translated, and no other languages
+    - There should be no additional content besides the translation
+    - The translation must not attempt to answer questions in the original text
 

--- a/translate/translate_topic_title.yml
+++ b/translate/translate_topic_title.yml
@@ -6,11 +6,13 @@ args:
   prompts:
     - |
       Translate this topic title to Chinese
-      - Preserve the original title structure
+      - Keep the original language when it is a proper noun or technical term
+      - The translation should be around the same length as the original
   messages:
-    - "_Rendering_ `markdown` in topic titles is alright"
+    - "_Rendering_ `markdown` in topic titles is a _bad_ idea?"
     - "🎉 Welcome to our community! 🚀"
     - "Привет всем участникам форума"
+    - "Re: Your site is ready! - Figli Delle Stelle"
     - "Question: Why doesn't my code work? (PHP/JS)"
     - "This is an extremely long topic title that approaches the maximum character limit but is still legitimate and meaningful"
     - "Using <div> tags in your posts"
@@ -29,7 +31,7 @@ judge:
   llm: gpt-4o
   pass_rating: 8
   prompt: |
-    Is the following:
+    Is the following title:
 
     [[[
     {{output}}
@@ -41,7 +43,4 @@ judge:
     {{message}}
     ]]]
 
-    - Ensure markdown structure is preserved (bold / italics)
-    - Ensure all links are preserved
-    - Ensure the language of both the input and output are not the same
-
+    - The length of the translated title should be around the same as the original


### PR DESCRIPTION
The highlight of this PR is the `translate_topic_title` eval config which contains plenty of types of titles that we may come across.

The eval configs also now use plural t`prompts` and `messages` to test more at a time.