### PR TITLE
FEATURE: New evals to check proofreader preserves quoted content

### DIFF
--- a/ai_helper/proofread_preserves_markdown_blockquote.yml
+++ b/ai_helper/proofread_preserves_markdown_blockquote.yml
@@ -1,0 +1,15 @@
+id: proofread_preserves_markdown_blockquote
+name: Preserve markdown blockquotes when proofreading
+description: Ensures proofreading fixes the author's text without editing quoted markdown lines
+feature: ai_helper:proofread
+args:
+  input: |
+    I definately agree with this:
+
+    > Teh feature shoud not touch quoted text.
+judge:
+  pass_rating: 9
+  criteria: |
+    - Leave the markdown blockquote line exactly unchanged, including its typo and punctuation.
+    - Proofread only the author's non-quoted sentence and correct the misspelling "definately".
+    - Preserve the markdown structure and paragraph breaks.

--- a/ai_helper/proofread_preserves_quote_block.yml
+++ b/ai_helper/proofread_preserves_quote_block.yml
@@ -1,0 +1,17 @@
+id: proofread_preserves_quote_block
+name: Preserve Discourse quote blocks when proofreading
+description: Ensures proofreading leaves Discourse quote blocks verbatim while fixing surrounding text
+feature: ai_helper:proofread
+args:
+  input: |
+    [quote="eviltrout, post:1, topic:123"]
+    Teh feature shoud not touch quoted text.
+    [/quote]
+
+    I definately agree with this.
+judge:
+  pass_rating: 9
+  criteria: |
+    - Leave the Discourse quote block exactly unchanged, including the opening tag, closing tag, inner text, typos, and punctuation.
+    - Proofread only the author's non-quoted sentence after the quote and correct the misspelling "definately".
+    - Preserve the existing quote-block structure and paragraph breaks.


### PR DESCRIPTION
Running: 

```
OPENAI_API_KEY=... CDCK_KEY=.. bundle exec ruby plugins/discourse-ai/evals/run -e proofread_preserves_quote_block -m cdck-model,gpt-5-nano --judge gpt-5.2
```

### Before

```
Starting evaluation eval run (1 cases)
CDCK: Failed 🔴
Error: LLM Rating below threshold, it was 2, expecting 9
GPT-5-Nano: Failed 🔴
Error: LLM Rating below threshold, it was 2, expecting 9

┌─────────────────────────────────┬─────────────────────────────────────────┬──────────────────────────────────────────┐
│ input                           │ CDCK                                    │ GPT-5-Nano                               │
├─────────────────────────────────┼─────────────────────────────────────────┼──────────────────────────────────────────┤
│ proofread_preserves_quote_block │ [FAIL]                                  │ [FAIL]                                   │
│                                 │ Actual: [quote="eviltrout, post:1,      │ Actual: [quote="eviltrout, post:1,       │
│                                 │ topic:123"…                             │ topic:123"…                              │
└─────────────────────────────────┴─────────────────────────────────────────┴──────────────────────────────────────────┘
Summary: CDCK: 0/1 pass | GPT-5-Nano: 0/1 pass
Legend: [PASS]=pass, [FAIL]=fail, [SKIP]=skipped, [TIE]=tie
```

### After tweaks

```
CDCK: Passed 🟢
GPT-5-Nano: Passed 🟢

┌─────────────────────────────────┬────────┬────────────┐
│ input                           │ CDCK   │ GPT-5-Nano │
├─────────────────────────────────┼────────┼────────────┤
│ proofread_preserves_quote_block │ [PASS] │ [PASS]     │
└─────────────────────────────────┴────────┴────────────┘
Summary: CDCK: 1/1 pass | GPT-5-Nano: 1/1 pass
Legend: [PASS]=pass, [FAIL]=fail, [SKIP]=skipped, [TIE]=tie

```

