### PR TITLE
DEV: More data explorer cases from real life usage

### DIFF
--- a/data_explorer/current_user_param.yml
+++ b/data_explorer/current_user_param.yml
@@ -1,0 +1,10 @@
+id: current_user_param
+name: Uses current_user_id for "me" queries
+description: |
+  When the user's prompt is first-person ("my posts", "queries about me"), the
+  agent should use the `current_user_id` system param, not a hardcoded user_id
+  or `:user = system`.
+feature: data_explorer:query_generation
+args:
+  input: "Show my posts and their reply counts"
+expected_output_regex: "current_user_id"

--- a/data_explorer/name_and_description.yml
+++ b/data_explorer/name_and_description.yml
@@ -1,0 +1,23 @@
+id: name_and_description
+name: Name fits the UI cap and description is informative
+description: |
+  The `name` field is shown in the Data Explorer UI which has a tight width;
+  it should fit in roughly 60 characters. The `description` should be at least
+  a short sentence so users picking the query later understand what it does.
+  The judge grades the `extra description` field below — not the SQL.
+feature: data_explorer:query_generation
+args:
+  input: "Daily reply count by trust level for the last 30 days"
+judge:
+  pass_rating: 7
+  criteria: |
+    The candidate output below is the generated SQL. Ignore the SQL itself —
+    instead grade the `extra name` and `extra description` fields the agent produced.
+
+    Rate 10 if:
+      - `extra name` is <= 60 characters AND
+      - `extra description` is a one-sentence description (at least 5 words) that names
+        what the query returns AND what the filters/parameters do.
+
+    Rate 7 if description describes the result clearly but omits parameter info.
+    Rate 3 if name > 60 chars OR description is vague / restates the prompt verbatim.

--- a/data_explorer/optional_categories_and_tags.yml
+++ b/data_explorer/optional_categories_and_tags.yml
@@ -1,0 +1,34 @@
+id: optional_categories_and_tags
+name: Optional plural filters — null prefix, list params, no tag_name hallucination
+description: |
+  When the user asks for an optional, plural set of filters ("optionally selected
+  categories and tags"), the agent must get THREE things right at once:
+    1. Optional params declared with the `null` prefix (e.g. `-- null category_id :category`),
+       not `:category = #null` as a default value.
+    2. No fabricated `tag_name` column (real column on `tags` is `name`).
+    3. Both "categories" AND "tags" handled as list-style params, since the prompt was plural.
+
+  Reproduces the scenario reported at
+  https://meta.discourse.org/t/first-impressions-on-ai-enabled-data-explorer/401212
+  where the agent failed all three on the same query.
+feature: data_explorer:query_generation
+args:
+  input: "Get topic IDs for optionally selected categories and tags."
+judge:
+  pass_rating: 8
+  criteria: |
+    Grade the SQL on three things. All three must pass to score 10.
+    1. Optional params: every declared param must use the `null` prefix (e.g. `-- null category_id :category`).
+       It must NOT use `= #null` as a default value (e.g. `-- category_id :category = #null` is wrong).
+    2. Schema accuracy: the SQL must NOT reference `tag_name` as a column on any table (the actual
+       column on `tags` is `name`). Any occurrence of `tg.tag_name`, `tags.tag_name`,
+       `tt.tag_name`, or `topic_tags.tag_name` is a hard fail.
+    3. Plural handling: BOTH "categories" and "tags" should be handled as list-style params
+       (`int_list`, `category_id` accepting multiple values, `string_list`, etc.), since the
+       prompt was plural.
+
+    Scoring:
+    - 10 = all three correct.
+    - 7 = #1 and #2 correct, but #3 only handles one of the two as a list.
+    - 4 = at most one of the three correct.
+    - 1 = none correct.

--- a/data_explorer/plural_to_list_param.yml
+++ b/data_explorer/plural_to_list_param.yml
@@ -1,0 +1,10 @@
+id: plural_to_list_param
+name: Plural prompt uses list-style params
+description: |
+  When the prompt uses plural ("categories", "tags"), the agent should use a
+  list-style param (e.g. `string_list`, `int_list`) rather than a single-value
+  param, so users can filter on multiple values.
+feature: data_explorer:query_generation
+args:
+  input: "Show topics that match selected categories and tags"
+expected_output_regex: "(int_list|string_list|user_list|group_list)"

--- a/data_explorer/schema_accuracy_tags.yml
+++ b/data_explorer/schema_accuracy_tags.yml
@@ -1,0 +1,20 @@
+id: schema_accuracy_tags
+name: Tags column is `name`, not `tag_name`
+description: |
+  The agent should use the `tags.name` column (the actual column in the schema).
+  Meta thread reported the small LLM using `tags.tag_name` / `tt.tag_name`, which
+  doesn't exist. The agent has a schema tool; this case asserts it doesn't fabricate
+  the column.
+feature: data_explorer:query_generation
+args:
+  input: "List topics that have a given tag"
+expected_output_regex: "FROM\\s+topics"
+judge:
+  pass_rating: 8
+  criteria: |
+    The candidate output is the generated SQL. Fail (rate 3 or below) if the SQL references
+    `tag_name` as a column on any table — e.g. `tg.tag_name`, `tags.tag_name`, `tt.tag_name`,
+    `topic_tags.tag_name`. The real tag-name column is `tags.name`.
+
+    Pass (rate 9–10) if the SQL references `tags.name` / `<alias>.name` correctly to filter
+    topics by tag.

--- a/data_explorer/start_end_date_params.yml
+++ b/data_explorer/start_end_date_params.yml
@@ -1,0 +1,20 @@
+id: start_end_date_params
+name: Date range uses start_date and end_date params
+description: |
+  When the user asks for a date range, the agent should declare two date params
+  named start_date and end_date with castable ISO defaults, and cast them via CAST().
+feature: data_explorer:query_generation
+args:
+  input: "Show me topic counts created between two dates"
+expected_output_regex: "\\[params\\]"
+judge:
+  pass_rating: 8
+  criteria: |
+    Grade the generated SQL:
+    1. Has a `-- [params]` block declaring two date params (any two; ideally named `start_date` and `end_date`).
+    2. Defaults are valid ISO dates in YYYY-MM-DD form, not natural-language ("today", "3 months ago", "14 jul 2015").
+    3. Date params are cast via `CAST(:param AS date)` (or AS timestamp) when used; NEVER `:param::date`.
+    4. The SQL does not end with a semicolon.
+
+    Rate 10 if all four pass. Rate 5 if a param is missing OR a default is natural-language.
+    Rate 3 if `:param::type` casting is used. Rate 1 if no params block at all.


### PR DESCRIPTION
 6 new cases for `data_explorer`, covering things that have shown up with user testing.

  - `optional_categories_and_tags`: null prefix, no `tag_name` column, plural nouns to list params
  - `schema_accuracy_tags`: must use `tags.name`, not invent `tag_name`
  - `start_end_date_params`: date range → CAST(:start_date AS date), ISO defaults, no `:param::date`.
  - `plural_to_list_param`: plural to list-style param.
  - `name_and_description`: name fits the UI, description is informative.
  - `current_user_param`: "my X" to `current_user_id`.

Related PR in core https://github.com/discourse/discourse/pull/40152 updates the prompt + DbSchema fixes that get us to 20/20 on Qwen 3.5-122B (hosted model) and Gemini 3.1 Flash Lite (with judge: GPT-5.2).